### PR TITLE
Update Tableau download recipe for architecture support

### DIFF
--- a/Tableau/Tableau_Desktop.download.recipe.yaml
+++ b/Tableau/Tableau_Desktop.download.recipe.yaml
@@ -9,20 +9,28 @@ Input:
   DOWNLOAD_MISSING_FILE: null
 
 Process:
+  # Example URLs once you have a free Tableau account:
+  #   - https://downloads.tableau.com/esdalt/2025.2.3/TableauDesktop-2025-2-3.dmg
+  #   - https://downloads.tableau.com/esdalt/2025.2.3/TableauDesktop-2025-2-3-arm64.dmg
+
+  - Processor: URLTextSearcher
+    Arguments:
+      re_pattern: <a href="(\/.*?)+\/(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+))#.*class="cta">
+      url: https://www.tableau.com/support/releases
+
   - Processor: com.github.smithjw-actions.processors/URLDownloaderPython
     Arguments:
       download_missing_file: '%DOWNLOAD_MISSING_FILE%'
       filename: '%SOFTWARE_TITLE%-x86_64.dmg'
-      url: https://www.tableau.com/downloads/desktop/mac
+      url: https://downloads.tableau.com/esdalt/%version%/TableauDesktop-%major%-%minor%-%patch%.dmg
 
   - Processor: com.github.smithjw-actions.processors/URLDownloaderPython
     Arguments:
       download_missing_file: '%DOWNLOAD_MISSING_FILE%'
       filename: '%SOFTWARE_TITLE%-arm64.dmg'
-      url: https://www.tableau.com/downloads/desktop/reg-mac-arm64
+      url: https://downloads.tableau.com/esdalt/%version%/TableauDesktop-%major%-%minor%-%patch%-arm64.dmg
 
   - Processor: EndOfCheckPhase
-
   - Processor: com.github.jgstew.SharedProcessors/StopProcessingIfDownloadUnchanged
     Arguments:
       bypass_stop_processing_if: '%BYPASS_STOP_PROCESSING_IF_DOWNLOAD_UNCHANGED%'
@@ -41,4 +49,4 @@ Process:
         - 'Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)'
         - Developer ID Certification Authority
         - Apple Root CA
-      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau.pkg'
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau Desktop.pkg'

--- a/Tableau/Tableau_Desktop.download.recipe.yaml
+++ b/Tableau/Tableau_Desktop.download.recipe.yaml
@@ -1,4 +1,4 @@
-Description: Downloads latest Tableau Desktop disk image.
+Description: Downloads latest Tableau Desktop disk images for both Intel and ARM architectures.
 Identifier: com.github.smithjw-actions.download.Tableau_Desktop
 MinimumVersion: '2.3'
 
@@ -12,8 +12,14 @@ Process:
   - Processor: com.github.smithjw-actions.processors/URLDownloaderPython
     Arguments:
       download_missing_file: '%DOWNLOAD_MISSING_FILE%'
-      filename: '%SOFTWARE_TITLE%.dmg'
+      filename: '%SOFTWARE_TITLE%-x86_64.dmg'
       url: https://www.tableau.com/downloads/desktop/mac
+
+  - Processor: com.github.smithjw-actions.processors/URLDownloaderPython
+    Arguments:
+      download_missing_file: '%DOWNLOAD_MISSING_FILE%'
+      filename: '%SOFTWARE_TITLE%-arm64.dmg'
+      url: https://www.tableau.com/downloads/desktop/reg-mac-arm64
 
   - Processor: EndOfCheckPhase
 
@@ -27,4 +33,12 @@ Process:
         - 'Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)'
         - Developer ID Certification Authority
         - Apple Root CA
-      input_path: '%pathname%/Tableau Desktop.pkg'
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Tableau Desktop.pkg'
+
+  - Processor: CodeSignatureVerifier
+    Arguments:
+      expected_authority_names:
+        - 'Developer ID Installer: Tableau Software, LLC (QJ4XPRK37C)'
+        - Developer ID Certification Authority
+        - Apple Root CA
+      input_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau.pkg'

--- a/Tableau/Tableau_Desktop.pkg.recipe.yaml
+++ b/Tableau/Tableau_Desktop.pkg.recipe.yaml
@@ -10,7 +10,7 @@ Input:
 Process:
   - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
     Arguments:
-      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau.pkg'
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau Desktop.pkg'
       file_to_extract: Distribution
 
   - Processor: com.github.mlbz521.SharedProcessors/XPathParser
@@ -29,7 +29,7 @@ Process:
 
   - Processor: Copier
     Arguments:
-      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau.pkg'
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau Desktop.pkg'
       destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.pkg'
 
   - Processor: Copier

--- a/Tableau/Tableau_Desktop.pkg.recipe.yaml
+++ b/Tableau/Tableau_Desktop.pkg.recipe.yaml
@@ -1,4 +1,4 @@
-Description: Downloads latest Tableau Desktop disk image and makes a pkg.
+Description: Downloads latest Tableau Desktop disk images and creates a universal pkg that installs the correct architecture.
 Identifier: com.github.smithjw-actions.pkg.Tableau_Desktop
 ParentRecipe: com.github.smithjw-actions.download.Tableau_Desktop
 MinimumVersion: '2.3'
@@ -10,7 +10,7 @@ Input:
 Process:
   - Processor: com.github.mlbz521.SharedProcessors/XarExtractSingleFile
     Arguments:
-      archive_path: '%pathname%/Tableau Desktop.pkg'
+      archive_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau.pkg'
       file_to_extract: Distribution
 
   - Processor: com.github.mlbz521.SharedProcessors/XPathParser
@@ -20,13 +20,50 @@ Process:
       xml_file: '%extracted_file%'
       xpath: .//pkg-ref//bundle[@id='com.tableausoftware.tableaudesktop'][@CFBundleShortVersionString]
 
-  - Processor: PkgCopier
+  - Processor: PkgRootCreator
     Arguments:
-      pkg_path: '%RECIPE_CACHE_DIR%/%SOFTWARE_TITLE%-%version%.pkg'
-      source_pkg: '%pathname%/Tableau Desktop.pkg'
+      pkgroot: '%RECIPE_CACHE_DIR%/payload'
+      pkgdirs:
+        pkgroot: '0775'
+        scripts: '0775'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-arm64.dmg/Tableau.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-arm64.pkg'
+
+  - Processor: Copier
+    Arguments:
+      source_path: '%RECIPE_CACHE_DIR%/downloads/%SOFTWARE_TITLE%-x86_64.dmg/Tableau Desktop.pkg'
+      destination_path: '%RECIPE_CACHE_DIR%/payload/scripts/%SOFTWARE_TITLE%-x86_64.pkg'
+
+  - Processor: FileCreator
+    Arguments:
+      file_path: '%RECIPE_CACHE_DIR%/payload/scripts/postinstall'
+      file_mode: '0755'
+      file_content: |
+        #!/bin/bash
+        if [[ $( /usr/bin/arch ) = arm64* ]]; then
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-arm64.pkg -target /
+        else
+          /usr/sbin/installer -pkg %SOFTWARE_TITLE%-x86_64.pkg -target /
+        fi
+        exit 0
+
+  - Processor: PkgCreator
+    Arguments:
+      pkg_request:
+        id: com.tableausoftware.tableaudesktop
+        options: purge_ds_store
+        pkgdir: '%RECIPE_CACHE_DIR%'
+        pkgname: '%SOFTWARE_TITLE%-%version%'
+        pkgroot: '%RECIPE_CACHE_DIR%/payload/pkgroot'
+        scripts: '%RECIPE_CACHE_DIR%/payload/scripts'
+        version: '%version%'
 
   - Processor: com.github.smithjw.processors/FriendlyPathDeleter
     Arguments:
       fail_deleter_silently: true
       path_list:
+        - '%RECIPE_CACHE_DIR%/payload'
         - '%RECIPE_CACHE_DIR%/extractedfile'


### PR DESCRIPTION
Hey @smithjw 

I've made an adjustment for the Tableau recipe to include ARM native support given the existing URL installs an intel ver.

Cheers,
Massimo